### PR TITLE
Fix task groups and returned tasks style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Logs
+log*

--- a/src/task/task.model.ts
+++ b/src/task/task.model.ts
@@ -29,8 +29,11 @@ const taskSchema = new Schema({
     type: String,
     validate: [TaskValidator.isDescriptionValid, 'Invalid task description given.'],
   },
-  orgIds: {
-    type: [String],
+  groups: {
+    type: {
+      id: String,
+      name: String,
+    },
     required: true,
     default: [],
   },

--- a/src/task/task.routes.ts
+++ b/src/task/task.routes.ts
@@ -92,7 +92,7 @@ export class TaskRouter {
       const tasks = await TaskController.getParentTasksByType(type as TaskType);
 
       // If tasks found
-      if (tasks && tasks.length > 0) {
+      if (tasks) {
         return res.status(200).send(tasks);
       }
 
@@ -117,7 +117,7 @@ export class TaskRouter {
       const tasks = await TaskController.getTasksByParentId(parentId);
 
       // If tasks found, return them
-      if (tasks && tasks.length > 0) {
+      if (tasks) {
         return res.status(200).send({ tasks });
       }
 


### PR DESCRIPTION
### Description
Change tasks `orgIds` field to `groups` and return empty arrays when querying about tasks instead of returning 404 error.